### PR TITLE
Address build bug for manifests without metadata.

### DIFF
--- a/src/lib/build/aggregate.js
+++ b/src/lib/build/aggregate.js
@@ -113,7 +113,7 @@ module.exports.build = async (env) => {
         label: manifest?.label,
         ...(settings?.summary?.enabled && { summary: manifest.summary }),
         ...(settings?.metadata?.enabled && {
-          metadata: manifest.metadata.filter((entry) =>
+          metadata: manifest.metadata?.filter((entry) =>
             settings.metadata.all
               ? entry
               : env.metadata.includes(getEntries(entry.label)[0])
@@ -121,7 +121,7 @@ module.exports.build = async (env) => {
         }),
       });
 
-      manifest.metadata.forEach((metadata) => {
+      manifest.metadata?.forEach((metadata) => {
         const metadataLabel = getEntries(metadata.label)[0];
         const metadataValues = getEntries(metadata.value);
         if (env?.metadata?.includes(metadataLabel)) {


### PR DESCRIPTION
# What does this do?

@cboucher01 This should resolve your build issues that you were seeing. You uncovered a bug where Canopy makes an assumption that all `Manifest` resources have a `metadata` value. I'll work this change into core Canopy as well. 

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/256cf4bd-7c63-41f4-9392-d87bd1373f7f" />


